### PR TITLE
Post one toot at a time, save lastProcessedPostId after each one

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,7 +64,7 @@ async function fetchNewPosts() {
 
   let newTimestampId = 0;
   
-  reversed.forEach(item => {
+  for(let item of reversed) {
     const currentTimestampId = Date.parse(item.published);
 
     if(currentTimestampId > newTimestampId) {
@@ -73,7 +73,9 @@ async function fetchNewPosts() {
 
    if(currentTimestampId > lastProcessedPostId && lastProcessedPostId != 0) {
       const text = removeHtmlTags(item.object.content);
-      postToBluesky(text);
+      await postToBluesky(text);
+      lastProcessedPostId = newTimestampId;
+      await saveLastProcessedPostId();
     }
   })
 


### PR DESCRIPTION
⚠️ Untested change ⚠️ 

This jumped out at me as a potential problem if there were a number of toots to be cross-posted in one go: Firing them all off at once means that they could potentially end up on bluesky out-of-order.

Additionally, if any failed to cross-post, saving after each successful one would allow the script to later pick up where it left off.

I was thinking about changing the script to copy over all of my toots, not just future ones, but I realized that just writing a 1 to the lastProcessedPostId.txt would do that, and then this change would ensure it went in order and was recoverable.

I'll try to test it out sometime soon - I was going to open an issue, but I figured it'd be easier to make the change than to describe it.